### PR TITLE
update setting keys to deno env

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,16 +1,16 @@
 export function parse(string: string) {
 	const lines = string.split(/\n|\r|\r\n/).filter(line => line.startsWith("#") ? false : !!line);
-	
+
 	return Object.fromEntries(lines.map(entry => {
 		let [key, val] = entry.split("=");
 		const quoteRegex = /^['"](.*)['"]$/;
-		
+
 		if (quoteRegex.test(val)) {
 			val = val.replace(quoteRegex, "$1");
 		} else {
 			val = val.trim();
 		}
-		
+
 		return [key, val];
 	}));
 }
@@ -19,9 +19,10 @@ export async function load(path: string = ".env") {
 	const file = await Deno.readFile(path);
 	const decoder = new TextDecoder();
 	const dotEnvs = parse(decoder.decode(file));
-	
+
 	for (const [key, val] of Object.entries(dotEnvs)) {
-		Deno.env.set(key, val);
+		const env = Deno.env();
+		env[key] = val;
 	}
 }
 


### PR DESCRIPTION
According to the new version of deno, setting a new key can't be done using : `Deno.env.set(key,val) `. You will get this error, with the new version of deno:
```
TS2339: Property 'set' does not exist on type '{ (): { [index: string]: string; }; (key: string): string | undefined; }'.

24      Deno.env.set(key, val);
              ~~~
```
In my PR, I update the mod.ts file to take into consideration this issue.