### PR TITLE
use references in regex

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: ci
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Deno environment
+        uses: denolib/setup-deno@master
+
+      - name: Deno Fmt Check
+        run: deno fmt --check
+
+      - name: Deno Test
+        run: deno test --allow-env --allow-read

--- a/README.md
+++ b/README.md
@@ -2,13 +2,9 @@
 A module similar to [dotenv](https://github.com/motdotla/dotenv), but for Deno
 
 ## Usage
-You can directly import it, and it will use the `.env` file of the directory it is imported in:
+You can import the `load` function which will use the `.env` file from the current directory, or you can pass the path to an `env` file:
 ```ts
-import "https://deno.land/x/denv/mod.ts";
-```
-else you can import the `load` function, where you can pass the path to the `.env` file:
-```ts
-import {load} from "https://deno.land/x/denv/mod.ts";
+import { load } from "https://deno.land/x/denv@1.0.0/mod.ts";
 await load("myenvfile");
 ```
 

--- a/mod.ts
+++ b/mod.ts
@@ -1,29 +1,30 @@
 export function parse(string: string) {
-	const lines = string.split(/\n|\r|\r\n/).filter(line => line.startsWith("#") ? false : !!line);
+  const lines = string.split(/\n|\r|\r\n/).filter((line) =>
+    line.startsWith("#") ? false : !!line
+  );
 
-	return Object.fromEntries(lines.map(entry => {
-		let [key, val] = entry.split("=");
-		const quoteRegex = /^['"](.*)['"]$/;
+  return Object.fromEntries(lines.map((entry) => {
+    let [key, val] = entry.split("=");
+    const quoteRegex = /^['"](.*)['"]$/;
 
-		if (quoteRegex.test(val)) {
-			val = val.replace(quoteRegex, "$1");
-		} else {
-			val = val.trim();
-		}
+    if (quoteRegex.test(val)) {
+      val = val.replace(quoteRegex, "$1");
+    } else {
+      val = val.trim();
+    }
 
-		return [key.trim(), val];
-	}));
+    return [key.trim(), val];
+  }));
 }
 
 export async function load(path: string = ".env") {
-	const file = await Deno.readFile(path);
-	const decoder = new TextDecoder();
-	const dotEnvs = parse(decoder.decode(file));
+  const file = await Deno.readFile(path);
+  const decoder = new TextDecoder();
+  const dotEnvs = parse(decoder.decode(file));
 
-	for (const [key, val] of Object.entries(dotEnvs)) {
-		Deno.env.set(key, val);
-	}
+  for (const [key, val] of Object.entries(dotEnvs)) {
+    Deno.env.set(key, val);
+  }
 }
-
 
 await load();

--- a/mod.ts
+++ b/mod.ts
@@ -3,10 +3,10 @@ export function parse(string: string) {
 
 	return Object.fromEntries(lines.map(entry => {
 		let [key, val] = entry.split("=");
-		const quoteRegex = /^['"](.*)['"]$/;
+		const quoteRegex = /^(['"])(.*)(\1)$/;
 
 		if (quoteRegex.test(val)) {
-			val = val.replace(quoteRegex, "$1");
+			val = val.replace(quoteRegex, "$2");
 		} else {
 			val = val.trim();
 		}

--- a/mod.ts
+++ b/mod.ts
@@ -5,10 +5,10 @@ export function parse(string: string) {
 
   return Object.fromEntries(lines.map((entry) => {
     let [key, val] = entry.split("=");
-    const quoteRegex = /^['"](.*)['"]$/;
+    const quoteRegex = /^(['"])(.*)(\1)$/;
 
     if (quoteRegex.test(val)) {
-      val = val.replace(quoteRegex, "$1");
+      val = val.replace(quoteRegex, "$2");
     } else {
       val = val.trim();
     }

--- a/mod.ts
+++ b/mod.ts
@@ -26,5 +26,3 @@ export async function load(path: string = ".env") {
     Deno.env.set(key, val);
   }
 }
-
-await load();

--- a/tests/.env
+++ b/tests/.env
@@ -1,0 +1,2 @@
+FOO = bar
+HELLO = "world"

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,0 +1,14 @@
+import { assertEquals } from "https://deno.land/std@0.63.0/testing/asserts.ts";
+import { load } from "../mod.ts";
+
+Deno.test("unquoted", async () => {
+  await load("./tests/.env");
+
+  assertEquals(Deno.env.get("FOO"), "bar");
+});
+
+Deno.test("quoted", async () => {
+  await load("./tests/.env");
+
+  assertEquals(Deno.env.get("HELLO"), "\"world\"");
+});

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -10,5 +10,5 @@ Deno.test("unquoted", async () => {
 Deno.test("quoted", async () => {
   await load("./tests/.env");
 
-  assertEquals(Deno.env.get("HELLO"), "\"world\"");
+  assertEquals(Deno.env.get("HELLO"), '"world"');
 });


### PR DESCRIPTION
this will parse when the user use single quote or double quote and has to close with the same character
you can try also with `/^(['"])(.*)((?<!\\)\1)$/;` to escape quotes